### PR TITLE
adding-html-url-to-database-schema

### DIFF
--- a/gitkanban/models.py
+++ b/gitkanban/models.py
@@ -83,6 +83,7 @@ class Issue(BaseMixin, Base):
     number = Column(Integer)
     title = Column(Unicode(255))
     body = Column(Unicode)
+    url = Column(Unicode(255))
 
     state = Column(String(32))  # FIXME: enum?
     closed_at = DateTime()


### PR DESCRIPTION
This HTML URL will be useful to understand if an issue is a Pull request or not which will be internally helpful in waffle dashboard and also added option for syncing without comments of issues

Will be working on the partialy sync script to make the database up to date if there are any issues with webhook listener, In that script we can sync comments